### PR TITLE
Update HasStateMachine::DefinitionTest name

### DIFF
--- a/test/has_state_machine/definition_test.rb
+++ b/test/has_state_machine/definition_test.rb
@@ -10,7 +10,7 @@ class Foobar < ActiveRecord::Base
   has_state_machine states: %i[foo bar]
 end
 
-class WorkflowTest < ActiveSupport::TestCase
+class HasStateMachine::DefinitionTest < ActiveSupport::TestCase
   subject { Foobar.new }
 
   describe "#has_state_machine" do


### PR DESCRIPTION
Realized I missed this when reviewing your PR to rename the gem