### PR TITLE
Slight change to the transition_to options

### DIFF
--- a/lib/has_state_machine/definition.rb
+++ b/lib/has_state_machine/definition.rb
@@ -56,7 +56,7 @@ module HasStateMachine
 
         ##
         # Determines whether or not the state validations should be run
-        # as part of the object validations.
+        # as part of the object validations; they are by default.
         define_singleton_method "state_validations_on_object?" do
           return true unless options.key?(:state_validations_on_object)
 

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -8,7 +8,7 @@ module HasStateMachine
     extend ActiveModel::Callbacks
     include ActiveModel::Validations
 
-    attr_reader :object, :state, :options
+    attr_reader :object, :state
 
     ##
     # Defines the before_transition and after_transition callbacks
@@ -28,8 +28,7 @@ module HasStateMachine
     # Initializes the HasStateMachine::State instance.
     #
     # @example
-    #   state = HasStateMachine::State.new(post) #=> "draft"
-    #   state.class #=> Workflow::Post::Draft
+    #   state = Workflow::Post::Draft.new(post) #=> "draft"
     def initialize(object)
       @object = object
 
@@ -78,7 +77,7 @@ module HasStateMachine
     end
 
     def valid_transition?(desired_state)
-      return true if options[:skip_validations]
+      return true if object.skip_state_validations
 
       object.valid? &&
         can_transition?(desired_state) &&
@@ -86,7 +85,6 @@ module HasStateMachine
     end
 
     def with_transition_options(options, &block)
-      @options = options
       object.skip_state_validations = options[:skip_validations]
       yield
       object.skip_state_validations = false

--- a/lib/has_state_machine/state_helpers.rb
+++ b/lib/has_state_machine/state_helpers.rb
@@ -5,6 +5,10 @@ module HasStateMachine
     extend ActiveSupport::Concern
 
     included do
+      ##
+      # Sometimes you may want to skip the validations defined on
+      # the state when validating your object; set this accessor
+      # to true to do so.
       attr_accessor :skip_state_validations
 
       delegate \
@@ -20,8 +24,9 @@ module HasStateMachine
       attribute state_attribute, :string, default: initial_state
 
       ##
-      # Validating any changes to the status attribute are represented by
-      # classes within the state machine and have a valid HasStateMachine::State class.
+      # Validate that the current state is a possible state, that there is a
+      # state class defined for it, and run the validations from the state
+      # class instance if need be.
       validates state_attribute, inclusion: {in: workflow_states}, presence: true
       validate :state_class_defined?
       validate :state_instance_validations, if: :should_validate_state?
@@ -44,7 +49,7 @@ module HasStateMachine
 
       workflow_states.each do |state|
         ##
-        # Defines scopes based on the state machine possible states
+        # Defines scopes based on the state machine's possible states
         #
         # @return [ActiveRecord_Relation]
         # @example Retreiving a users published posts
@@ -102,8 +107,8 @@ module HasStateMachine
       end
 
       ##
-      # Runs the validations defined on the current HasStateMachine::State when calling
-      # model.valid?
+      # Run the validations defined on the current HasStateMachine::State. Errors found there
+      # should be added to this object.
       def state_instance_validations
         return unless state_class.present?
 


### PR DESCRIPTION
This PR changes how the options passed into `transition_to` work under the hood slightly. With how they are currently being used, there is not really any need for the attr_reader for those options.

This also updates some comments throughout the gem to be more concise/clear.