### PR TITLE
Fix HasStateMachine#transition_to always returning false ;B

### DIFF
--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -46,11 +46,15 @@ module HasStateMachine
     #
     # @return [Boolean] whether or not the transition took place
     def transition_to(desired_state, **options)
+      transitioned = false
+
       with_transition_options(options) do
         return false unless valid_transition?(desired_state.to_s)
 
-        state_instance(desired_state.to_s).perform_transition!
+        transitioned = state_instance(desired_state.to_s).perform_transition!
       end
+
+      transitioned
     end
 
     ##

--- a/test/has_state_machine/definition_test.rb
+++ b/test/has_state_machine/definition_test.rb
@@ -2,16 +2,16 @@
 
 require "test_helper"
 
-ActiveRecord::Migration.create_table :foobars, force: true do |t|
+ActiveRecord::Migration.create_table :hikers, force: true do |t|
   t.string :status
 end
 
-class Foobar < ActiveRecord::Base
+class Hiker < ActiveRecord::Base
   has_state_machine states: %i[foo bar]
 end
 
 class HasStateMachine::DefinitionTest < ActiveSupport::TestCase
-  subject { Foobar.new }
+  subject { Hiker.new }
 
   describe "#has_state_machine" do
     it "includes the correct module" do
@@ -39,7 +39,7 @@ class HasStateMachine::DefinitionTest < ActiveSupport::TestCase
         it { subject.respond_to? :workflow_namespace }
 
         it "returns the correct value" do
-          assert_equal "Workflow::Foobar", subject.workflow_namespace
+          assert_equal "Workflow::Hiker", subject.workflow_namespace
         end
       end
 

--- a/test/has_state_machine/state_helpers_test.rb
+++ b/test/has_state_machine/state_helpers_test.rb
@@ -14,11 +14,7 @@ module Workflow
   module Mountain
     class Foo < HasStateMachine::State
     end
-  end
-end
 
-module Workflow
-  module Mountain
     class Baz < HasStateMachine::State
       validate :failing_validation
 

--- a/test/has_state_machine/state_helpers_test.rb
+++ b/test/has_state_machine/state_helpers_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+ActiveRecord::Migration.create_table :mountains, force: true do |t|
+  t.string :status
+end
+
+class Mountain < ActiveRecord::Base
+  has_state_machine states: %i[foo bar baz]
+end
+
+module Workflow
+  module Mountain
+    class Foo < HasStateMachine::State
+    end
+  end
+end
+
+module Workflow
+  module Mountain
+    class Baz < HasStateMachine::State
+      validate :failing_validation
+
+      def failing_validation
+        errors.add(:base, "dummy validation failed")
+      end
+    end
+  end
+end
+
+class HasStateMachine::StateHelpersTest < ActiveSupport::TestCase
+  subject { Mountain.new }
+
+  describe "delegated methods" do
+    it { assert subject.respond_to? :state_attribute }
+    it { assert subject.respond_to? :state_validations_on_object? }
+    it { assert subject.respond_to? :workflow_namespace }
+    it { assert subject.respond_to? :workflow_states }
+  end
+
+  it "defaults instance to initial state" do
+    assert_equal "foo", subject.status
+  end
+
+  describe "validations" do
+    it "is valid if state attribute is a valid state" do
+      subject.status = "foo"
+      assert subject.valid?
+    end
+
+    it "is invalid if state attribute is an invalid state" do
+      subject.status = "random"
+      refute subject.valid?
+    end
+
+    it "is invalid if state does not have class defined" do
+      subject.status = "bar"
+      refute subject.valid?
+    end
+
+    it "is invalid if state validations do not pass" do
+      subject.status = "baz"
+      refute subject.valid?
+    end
+
+    it "ignores state validations if accessor is set" do
+      subject.status = "baz"
+      subject.skip_state_validations = true
+
+      assert subject.valid?
+    end
+  end
+
+  describe "state attribute method" do
+    it "it returns an instance of HasStateMachine::State" do
+      assert_kind_of HasStateMachine::State, subject.status
+    end
+  end
+
+  describe "generated predicate methods" do
+    it { assert subject.foo? }
+    it { refute subject.bar? }
+    it { refute subject.baz? }
+  end
+
+  describe "generated scopes" do
+    it { assert_kind_of ActiveRecord::Relation, Mountain.foo }
+    it { assert_kind_of ActiveRecord::Relation, Mountain.bar }
+    it { assert_kind_of ActiveRecord::Relation, Mountain.foo }
+  end
+end

--- a/test/has_state_machine/state_test.rb
+++ b/test/has_state_machine/state_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+ActiveRecord::Migration.create_table :swimmers, force: true do |t|
+  t.string :status
+end
+
+class Swimmer < ActiveRecord::Base
+  attr_accessor :before_transition_boolean
+  attr_accessor :after_transition_boolean
+
+  has_state_machine states: %i[diving swimming floating]
+end
+
+module Workflow
+  module Swimmer
+    class Diving < HasStateMachine::State
+      transitions_to %i[swimming floating]
+    end
+
+    class Swimming < HasStateMachine::State
+      before_transition do
+        object.before_transition_boolean = true
+      end
+
+      after_transition do
+        object.after_transition_boolean = true
+      end
+    end
+
+    class Floating < HasStateMachine::State
+      validate :can_float?
+
+      def can_float?
+        errors.add(:base, "swimmer cannot float")
+      end
+    end
+  end
+end
+
+class HasStateMachine::StateTest < ActiveSupport::TestCase
+  let(:object) { Swimmer.new }
+  subject { Workflow::Swimmer::Diving.new(object) }
+
+  describe "#possible_transitions" do
+    it { assert_equal %w[swimming floating], subject.possible_transitions }
+  end
+
+  describe "#errors" do
+    it "delegates to the object" do
+      object.errors.add(:base, "foobar")
+
+      assert_equal({base: %w[foobar]}, subject.errors.messages)
+    end
+  end
+
+  describe "#transition_to" do
+    it "runs callbacks" do
+      refute object.before_transition_boolean
+      refute object.after_transition_boolean
+
+      subject.transition_to(:swimming)
+
+      assert object.before_transition_boolean
+      assert object.after_transition_boolean
+    end
+
+    it "updates the object's state attribute" do
+      assert_equal "diving", object.status
+
+      subject.transition_to(:swimming)
+
+      assert_equal "swimming", object.status
+    end
+
+    it "fails if transitioning to an invalid state" do
+      refute subject.transition_to(:running)
+      assert_equal "diving", object.status
+    end
+
+    it "fails if state validations fail" do
+      refute subject.transition_to(:floating)
+      assert_equal "diving", object.status
+    end
+
+    it "can skip state validations" do
+      assert subject.transition_to(:floating, skip_validations: true)
+      assert_equal "floating", object.status
+    end
+  end
+end


### PR DESCRIPTION
# Description

`HasStateMachine#transition_to` was returning false regardless of whether or not the transition succeeded. This also adds a bunch of tests for things that don't have any.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [x] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
