### PR TITLE
Update scope generation to check if ActiveRecord defined ;C

### DIFF
--- a/lib/has_state_machine/state_helpers.rb
+++ b/lib/has_state_machine/state_helpers.rb
@@ -55,7 +55,9 @@ module HasStateMachine
         # @example Retreiving a users published posts
         #   > Post.published.where(user: user)
         #   #=> [#<Post>]
-        scope state, -> { where("#{state_attribute} = ?", state) }
+        if defined?(ActiveRecord) && (self < ActiveRecord::Base)
+          scope state, -> { where("#{state_attribute} = ?", state) }
+        end
 
         ##
         # Defines boolean helpers to determine if the active state matches
@@ -76,7 +78,7 @@ module HasStateMachine
       # Getter for the current state of the model based on the configured state
       # attribute.
       def current_state
-        self[state_attribute]
+        attributes.with_indifferent_access[state_attribute]
       end
 
       ##


### PR DESCRIPTION
# Description

This PR updates the helpers to check if the including class inherits from ActiveRecord before trying to define scopes. It also changes the `#current_state` method to rely on the attributes api. I think this gives a little more flexibility in how this gem can be used. Now if your including class implements the attributes api and has an update method then you should be able to use this.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [x] 2. Minor (non-breaking, backwards compatible change)
- [ ] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
