### PR TITLE
Add Transactional Transitions ;F

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ post.status.transition_to(:archived)
 
 ### Advanced Usage
 
-Sometimes there may be a situation where you want to manually roll back a state change in one of the provided callbacks. To do this, add the `transactional: true` option to the `state_options` declaration and use the method `rollback_transition` in your callback. This will allow you to prevent the transition from persisting if something further down the line fails.
+Sometimes there may be a situation where you want to manually roll back a state change in one of the provided callbacks. To do this, add the `transactional: true` option to the `state_options` declaration and use the `rollback_transition` method in your callback. This will allow you to prevent the transition from persisting if something further down the line fails.
 
 ```ruby
 module Workflow

--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ HasStateMachine uses ruby classes to make creating a finite state machine for yo
 
 ## Contents
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Changelog](https://github.com/encampment/has_state_machine/blob/master/CHANGELOG.md)
-- [Contributing](#contributing)
-- [License](#license)
+- [HasStateMachine](#hasstatemachine)
+  - [Contents](#contents)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Advanced Usage](#advanced-usage)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -21,11 +24,13 @@ gem 'has_state_machine'
 ```
 
 And then execute:
+
 ```bash
 $ bundle
 ```
 
 Or install it yourself as:
+
 ```bash
 $ gem install has_state_machine
 ```
@@ -36,6 +41,7 @@ You must first use the `has_state_machine` macro to define your state machine at
 a high level. This includes defining the possible states for your object as well
 as some optional configuration should you want to change the default behavior of
 the state machine.
+
 ```ruby
 # By default, it is assumed that the "state" of the object is
 # stored in a string column named "status".
@@ -53,13 +59,13 @@ from `HasStateMachine::State`.
 module Workflow
   class Post::Draft < HasStateMachine::State
     # Define the possible transitions from the "draft" state
-    transitions_to %i[published archived]
+    state_options transitions_to: %i[published archived]
   end
 end
 
 module Workflow
   class Post::Published < HasStateMachine::State
-    transitions_to %i[archived]
+    state_options transitions_to: %i[archived]
 
     # Custom validations can be added to the state to ensure a transition is "valid"
     validate :title_exists?
@@ -111,6 +117,28 @@ post.status.transition_to(:archived)
 # => true
 ```
 
+### Advanced Usage
+
+Sometimes there may be a situation where you want to manually roll back a state change in one of the provided callbacks. To do this, add the `transactional: true` option to the `state_options` declaration and use the method `rollback_transition` in your callback. This will allow you to prevent the transition from persisting if something further down the line fails.
+
+```ruby
+module Workflow
+  class Post::Archived < HasStateMachine::State
+    state_options transactional: true
+
+    after_transition do
+      rollback_transition unless notified_watchers?
+    end
+
+    private
+
+    def notified_watchers?
+      #...
+    end
+  end
+end
+```
+
 ## Contributing
 
 Anyone is encouraged to help improve this project. Here are a few ways you can help:
@@ -130,4 +158,5 @@ bundle exec rake test
 ```
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -76,7 +76,7 @@ module HasStateMachine
     ##
     # Makes the actual transition from one state to the next and
     # runs the before and after transition callbacks in a transaction
-    # to allow for rollbacks.
+    # to allow for roll backs.
     def perform_transactional_transition!
       ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
         run_callbacks :transition do

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -52,13 +52,13 @@ module HasStateMachine
       with_transition_options(options) do
         return false unless valid_transition?(desired_state.to_s)
 
-        transitioned = state_instance(desired_state.to_s).then { |desired_state|
-          if desired_state.transactional?
-            desired_state.perform_transactional_transition!
-          else
-            desired_state.perform_transition!
-          end
-        }
+        desired_state = state_instance(desired_state.to_s)
+
+        transitioned = if desired_state.transactional?
+          desired_state.perform_transactional_transition!
+        else
+          desired_state.perform_transition!
+        end
       end
 
       transitioned

--- a/test/dummy/app/models/workflow/post/archived.rb
+++ b/test/dummy/app/models/workflow/post/archived.rb
@@ -2,6 +2,6 @@
 
 module Workflow
   class Post::Archived < Workflow::Base
-    transitions_to %i[published]
+    state_options transitions_to: %i[published]
   end
 end

--- a/test/dummy/app/models/workflow/post/draft.rb
+++ b/test/dummy/app/models/workflow/post/draft.rb
@@ -2,6 +2,6 @@
 
 module Workflow
   class Post::Draft < Workflow::Base
-    transitions_to %i[published archived]
+    state_options transitions_to: %i[published archived]
   end
 end

--- a/test/dummy/app/models/workflow/post/published.rb
+++ b/test/dummy/app/models/workflow/post/published.rb
@@ -2,7 +2,7 @@
 
 module Workflow
   class Post::Published < Workflow::Base
-    transitions_to %i[archived]
+    state_options transitions_to: %i[archived]
 
     validate :title_exists?
 


### PR DESCRIPTION
# Description

Adds Transactional Transitions

Sometimes there may be a situation where you want to manually roll back a state change in one of the provided callbacks. To do this, add the `transactional: true` option to the `state_options` declaration and use the `rollback_transition` method in your callback. This will allow you to prevent the transition from persisting if something further down the line fails.

```ruby
module Workflow
  class Post::Archived < HasStateMachine::State
    state_options transactional: true

    after_transition do
      rollback_transition unless notified_watchers?
    end

    private

    def notified_watchers?
      #...
    end
  end
end
```

## Checklist

- [X] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [X] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.
- [x] 2. Minor (non-breaking, backwards compatible change)

Co-authored by @jhurd2326 