### PR TITLE
Deprecate HasStateMachine::State#transitions_to ;D

### DIFF
--- a/lib/has_state_machine.rb
+++ b/lib/has_state_machine.rb
@@ -3,6 +3,7 @@
 require "has_state_machine/railtie"
 require "has_state_machine/core_ext/string"
 require "has_state_machine/definition"
+require "has_state_machine/deprecation"
 
 module HasStateMachine
 end

--- a/lib/has_state_machine/deprecation.rb
+++ b/lib/has_state_machine/deprecation.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "active_support/deprecation"
+
+module HasStateMachine
+  Deprecation = ActiveSupport::Deprecation.new("1.0", "HasStateMachine")
+end

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -143,6 +143,7 @@ module HasStateMachine
       # states the current state can transition to.
       def transitions_to(states)
         state_options(transitions_to: states)
+        HasStateMachine::Deprecation.deprecation_warning(:transitions_to, "use state_options instead")
       end
 
       ##


### PR DESCRIPTION
# Description

This PR deprecates `HasStateMachine::State#transitions_to` in favor of `state_options`

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [x] 2. Minor (non-breaking, backwards compatible change)
