### PR TITLE
Fix tests - Only test against rails main for ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,12 @@ jobs:
       - name: Lint
         run: bundle exec rake lint
 
-      - name: Tests
-        run: bundle exec rake test:all
+      - name: Test against rails main
+        if: ${{ matrix.ruby == 2.7 }}
+        run: bundle exec appraisal rails-main rake test
+
+      - name: Test against rails 6.0
+        run: bundle exec appraisal rails-6-0 rake test
+
+      - name: Test against rails 5.2
+        run: bundle exec appraisal rails-5-2 rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,18 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
 
-      - name: Install Apparaisal Dependencies
-        run: bundle exec appraisal install
-
       - name: Lint
         run: bundle exec rake lint
 
       - name: Test against rails main
         if: ${{ matrix.ruby == 2.7 }}
+        run: bundle exec appraisal rails-main bundle install
         run: bundle exec appraisal rails-main rake test
 
       - name: Test against rails 6.0
+        run: bundle exec appraisal rails-6-0 bundle install
         run: bundle exec appraisal rails-6-0 rake test
 
       - name: Test against rails 5.2
+        run: bundle exec appraisal rails-5-2 bundle install
         run: bundle exec appraisal rails-5-2 rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,16 @@ jobs:
 
       - name: Test against rails main
         if: ${{ matrix.ruby == 2.7 }}
-        run: bundle exec appraisal rails-main bundle install
-        run: bundle exec appraisal rails-main rake test
+        run: |
+          bundle exec appraisal rails-main bundle install
+          bundle exec appraisal rails-main rake test
 
       - name: Test against rails 6.0
-        run: bundle exec appraisal rails-6-0 bundle install
-        run: bundle exec appraisal rails-6-0 rake test
+        run: |
+          bundle exec appraisal rails-6-0 bundle install
+          bundle exec appraisal rails-6-0 rake test
 
       - name: Test against rails 5.2
-        run: bundle exec appraisal rails-5-2 bundle install
-        run: bundle exec appraisal rails-5-2 rake test
+        run: |
+          bundle exec appraisal rails-5-2 bundle install
+          bundle exec appraisal rails-5-2 rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
 
+      - name: Install Apparaisal Dependencies
+        run: bundle exec appraisal install
+
       - name: Lint
         run: bundle exec rake lint
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
# Description

Rails `main` has been updated to use `activesupport-7.0.0.alpha` which requires at least ruby 2.7. As a result, tests are broken for other ruby versions. We should now only test against rails main for ruby 2.7 or greater.
