### PR TITLE
remove: deprecated transition_to method

### DIFF
--- a/bin/refresh_changelog
+++ b/bin/refresh_changelog
@@ -192,9 +192,9 @@ AutoChangelog.configure do |config|
   config.entry_sections = [
     { title: "Bug Fixes", markers: [";B", "fix:"] },
     { title: "Changes", markers: [";C", "misc:"] },
-    { title: "Deprecations", markers: [";D"] },
+    { title: "Deprecations", markers: [";D", "deprecate:"] },
     { title: "Features", markers: [";F", "feat:"] },
-    { title: "Removed" , markers: [";R"] },
+    { title: "Removed" , markers: [";R", "remove:"] },
     { title: "Security", markers: [";S", "sec:"] }
   ]
 end

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -139,14 +139,6 @@ module HasStateMachine
       end
 
       ##
-      # Setter for the HasStateMachine::State classes to define the possible
-      # states the current state can transition to.
-      def transitions_to(states)
-        state_options(transitions_to: states)
-        HasStateMachine::Deprecation.deprecation_warning(:transitions_to, "use state_options instead")
-      end
-
-      ##
       # Set the options for the HasStateMachine::State classes to define the possible
       # states the current state can transition to and whether or not transitioning
       # to the state should be performed within a transaction.


### PR DESCRIPTION
# Description

This method has been deprecated for quite some time and I want to go ahead and remove it before the next major release.

## Checklist

- [ ] I added the appropriate label to this PR.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [x] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [ ] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
