### PR TITLE
feat: add after_transition_commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ module Workflow
       # after_transition callbacks as well.
       Rails.logger.info "== Transitioned from #{previous_state} ==\n"
     end
+
+    # after_transition_commit runs only once the transition has been
+    # committed: after the record is saved for normal transitions, and
+    # outside the transaction for transactional transitions (see below).
+    after_transition_commit do
+      MyJob.perform_later(object)
+    end
   end
 end
 ```
@@ -206,10 +213,20 @@ module Workflow
       rollback_transition unless notified_watchers?
     end
 
+    after_transition_commit do
+      enqueue_external_work
+    end
+
     private
 
+    def enqueue_external_work
+      # Any work you want to happen only after the transition is committed.
+      # Enqueuing a job, calling an external API, sending a webhook, etc.
+    end
+
     def notified_watchers?
-      #...
+      # Any dependent work that you want to run that should play a part in determining
+      # whether the transition was successful or not and needs to be rolled back.
     end
   end
 end

--- a/has_state_machine.gemspec
+++ b/has_state_machine.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-rails"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "minitest", "~> 5.1"
 end

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -16,6 +16,11 @@ module HasStateMachine
     define_model_callbacks :transition, only: %i[before after]
 
     ##
+    # Defines the after_transition_commit callback. It runs only after a
+    # transition has committed.
+    define_model_callbacks :transition_commit, only: %i[after]
+
+    ##
     # possible_transitions - Retrieves the next available transitions for a given state.
     # transactional? - Determines whether or not the transition should happen with a transactional block.
     # state - The underscored name of the state
@@ -80,25 +85,34 @@ module HasStateMachine
 
     ##
     # Makes the actual transition from one state to the next and
-    # runs the before and after transition callbacks.
+    # runs the before and after transition callbacks. The
+    # after_transition_commit callbacks run after the update completes
+    # and only when it succeeds.
     def perform_transition!
-      run_callbacks :transition do
-        object.update("#{object.state_attribute}": state)
+      run_callbacks :transition_commit do
+        run_callbacks :transition do
+          object.update("#{object.state_attribute}": state)
+        end
       end
     end
 
     ##
     # Makes the actual transition from one state to the next and
     # runs the before and after transition callbacks in a transaction
-    # to allow for roll backs.
+    # to allow for roll backs. The after_transition_commit callbacks run
+    # outside the transaction and only when it commits (not on rollback).
     def perform_transactional_transition!
-      ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
-        run_callbacks :transition do
-          rollback_transition unless object.update("#{object.state_attribute}": state)
+      run_callbacks :transition_commit do
+        ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
+          run_callbacks :transition do
+            rollback_transition unless object.update("#{object.state_attribute}": state)
+          end
         end
-      end
 
-      object.reload.public_send(object.state_attribute) == state
+        @previous_state = previous_state
+
+        object.reload.public_send(object.state_attribute) == state
+      end
     end
 
     private
@@ -112,7 +126,7 @@ module HasStateMachine
     # it has been transitioned to the new state. Useful in
     # after_transition blocks
     def previous_state
-      object.previous_changes[object.state_attribute]&.first
+      @previous_state.presence || object.previous_changes[object.state_attribute]&.first
     end
 
     def state_instance(desired_state, transient_values)

--- a/test/has_state_machine/state_test.rb
+++ b/test/has_state_machine/state_test.rb
@@ -9,7 +9,14 @@ end
 class Swimmer < ActiveRecord::Base
   attr_accessor :before_transition_boolean
   attr_accessor :after_transition_boolean
+  attr_accessor :after_transition_commit_boolean
   attr_accessor :previous_state
+  attr_accessor :previous_state_in_commit
+  attr_writer :callback_sequence
+
+  def callback_sequence
+    @callback_sequence ||= []
+  end
 
   has_state_machine states: %i[diving swimming floating tanning tubing lotioning]
 end
@@ -28,6 +35,13 @@ module Workflow
       after_transition do
         object.after_transition_boolean = true
         object.previous_state = previous_state
+        object.callback_sequence << :after_transition
+      end
+
+      after_transition_commit do
+        object.after_transition_commit_boolean = true
+        object.previous_state_in_commit = previous_state
+        object.callback_sequence << :after_transition_commit
       end
     end
 
@@ -64,6 +78,11 @@ module Workflow
 
       after_transition do
         rollback_transition unless needs_lotion_after
+      end
+
+      after_transition_commit do
+        object.after_transition_commit_boolean = true
+        object.previous_state_in_commit = previous_state
       end
     end
   end
@@ -118,6 +137,33 @@ class HasStateMachine::StateTest < ActiveSupport::TestCase
         subject.transition_to(:swimming)
         assert_equal "diving", object.previous_state
       end
+
+      it "runs after_transition_commit callbacks" do
+        refute object.after_transition_commit_boolean
+        subject.transition_to(:swimming)
+        assert object.after_transition_commit_boolean
+      end
+
+      it "runs after_transition_commit after after_transition" do
+        subject.transition_to(:swimming)
+        assert_equal %i[after_transition after_transition_commit], object.callback_sequence
+      end
+
+      it "has access to the previous state in after_transition_commit" do
+        assert object.previous_state_in_commit.nil?
+        subject.transition_to(:swimming)
+        assert_equal "diving", object.previous_state_in_commit
+      end
+
+      it "does not run after_transition_commit on an invalid transition" do
+        refute subject.transition_to(:running)
+        refute object.after_transition_commit_boolean
+      end
+
+      it "does not run after_transition_commit when state validations fail" do
+        refute subject.transition_to(:floating)
+        refute object.after_transition_commit_boolean
+      end
     end
 
     it "updates the object's state attribute" do
@@ -168,6 +214,26 @@ class HasStateMachine::StateTest < ActiveSupport::TestCase
         it "returns false if the transaction is rolled back in the before_transition" do
           assert_equal false, subject.transition_to(:lotioning, needs_lotion_before: false, needs_lotion_after: true)
           assert_equal "diving", object.reload.status.to_s
+        end
+
+        it "runs after_transition_commit when the transaction commits" do
+          subject.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: true)
+          assert object.after_transition_commit_boolean
+        end
+
+        it "does not run after_transition_commit when rolled back in the after_transition" do
+          subject.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: false)
+          refute object.after_transition_commit_boolean
+        end
+
+        it "does not run after_transition_commit when rolled back in the before_transition" do
+          subject.transition_to(:lotioning, needs_lotion_before: false, needs_lotion_after: true)
+          refute object.after_transition_commit_boolean
+        end
+
+        it "has access to the previous state in after_transition_commit" do
+          subject.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: true)
+          assert_equal "diving", object.previous_state_in_commit
         end
       end
     end


### PR DESCRIPTION
# Description

Adds a `after_transition_commit` hook that runs outside of a transactional transition's transaction after it is committed successfully. 

## Checklist

- [ ] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [x] 2. Minor (non-breaking, backwards compatible change)
- [ ] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
