### PR TITLE
misc: Update Gemfile.lock and publish script

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   has_state_machine!
+  minitest (~> 5.1)
   pry
   pry-rails
   sqlite3 (>= 1.5)

--- a/bin/publish
+++ b/bin/publish
@@ -127,8 +127,8 @@ if prompt == "Y"
   puts "--- Pushing Changes ---"
   `git push origin main`
 
-  puts "--- Publishing Gem ---"
-  `bundle exec rake release`
+  puts "--- Action Required: Publish Gem ---"
+  puts "Now run `bundle exec rake release` to publish the gem to rubygems"
 else
   puts "--- Aborting Gem Release ---"
 end


### PR DESCRIPTION
# Description

Update the Gemfile.lock based on the most recent commit. Also update the publish script to no longer attempt to publish to rubygems inline since it generally requires 2FA and makes the script hang.

## Checklist

- [ ] I added the appropriate label to this PR.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [ ] 3. Patch (non-breaking, backwards compatible bug fix)
- [x] 4. No immediate release is required
