### PR TITLE
fix: prevent timeouts for ruby lsp extension for large repos

### DIFF
--- a/lib/ruby_lsp/has_state_machine/definition.rb
+++ b/lib/ruby_lsp/has_state_machine/definition.rb
@@ -46,7 +46,7 @@ module RubyLsp
         return @resolved_model_name if defined?(@resolved_model_name)
         return @resolved_model_name = nil unless current_class_name
 
-        @resolved_model_name = model_name_from_rails(workflow_namespace) || convention_model_name
+        @resolved_model_name = convention_model_name || model_name_from_rails(workflow_namespace)
       end
 
       def convention_model_name

--- a/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
+++ b/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/string/inflections"
 require "ruby_lsp/ruby_lsp_rails/server"
+require_relative "workflow_resolver"
 
 module RubyLsp
   module HasStateMachine
@@ -23,14 +25,29 @@ module RubyLsp
       private
 
       def model_for_workflow_namespace(workflow_namespace)
-        model = models_by_workflow_namespace[workflow_namespace]
+        model = conventional_model_for_workflow_namespace(workflow_namespace) ||
+          loaded_model_for_workflow_namespace(workflow_namespace) ||
+          models_by_workflow_namespace[workflow_namespace]
         return unless model
 
         {name: model.name}
       end
 
+      def conventional_model_for_workflow_namespace(workflow_namespace)
+        return unless workflow_namespace.to_s.start_with?(WorkflowResolver::WORKFLOW_PREFIX)
+
+        model = workflow_namespace.to_s.delete_prefix(WorkflowResolver::WORKFLOW_PREFIX).safe_constantize
+        model if model_matches_workflow_namespace?(model, workflow_namespace)
+      end
+
+      def loaded_model_for_workflow_namespace(workflow_namespace)
+        active_record_models.find do |model|
+          model_matches_workflow_namespace?(model, workflow_namespace)
+        end
+      end
+
       def models_by_workflow_namespace
-        @models_by_workflow_namespace ||= active_record_models.each_with_object({}) do |model, index|
+        @models_by_workflow_namespace ||= eager_loaded_active_record_models.each_with_object({}) do |model, index|
           next unless model.respond_to?(:workflow_namespace)
 
           index[model.workflow_namespace] = model
@@ -38,10 +55,22 @@ module RubyLsp
       end
 
       def active_record_models
-        @active_record_models ||= begin
+        ::ActiveRecord::Base.descendants.reject(&:abstract_class?)
+      end
+
+      def eager_loaded_active_record_models
+        @eager_loaded_active_record_models ||= begin
           ::Rails.application&.eager_load!
-          ::ActiveRecord::Base.descendants.reject(&:abstract_class?)
+          active_record_models
         end
+      end
+
+      def model_matches_workflow_namespace?(model, workflow_namespace)
+        model.is_a?(Class) &&
+          model < ::ActiveRecord::Base &&
+          !model.abstract_class? &&
+          model.respond_to?(:workflow_namespace) &&
+          model.workflow_namespace == workflow_namespace
       end
     end
   end

--- a/test/ruby_lsp/has_state_machine/definition_test.rb
+++ b/test/ruby_lsp/has_state_machine/definition_test.rb
@@ -110,6 +110,48 @@ class RubyLsp::HasStateMachine::DefinitionTest < ActiveSupport::TestCase
       assert_equal ["file:///app/models/post.rb"], response.map(&:uri)
     end
 
+    it "does not ask Rails when the workflow resolves by convention" do
+      object_node = FakeCall.new("object")
+      rails_client = FakeRailsClient.new(
+        ["model_for_workflow_namespace", nil, nil, "Workflow::Post"] => {name: "CustomPost"}
+      )
+      response = []
+      listener = build_listener(
+        response: response,
+        node: object_node,
+        call_node: object_node,
+        index: FakeIndex.new(entries: {"Post" => [@entry]}),
+        rails_client: rails_client
+      )
+
+      listener.on_call_node_enter(object_node)
+
+      assert_equal ["file:///app/models/post.rb"], response.map(&:uri)
+      assert_empty rails_client.requests
+    end
+
+    it "resolves namespaced workflow models by convention" do
+      object_node = FakeCall.new("object")
+      email_entry = FakeEntry.new("file:///app/models/domain_configurations/email.rb", FakeLocation.new(1, 1, 6, 12))
+      rails_client = FakeRailsClient.new(
+        ["model_for_workflow_namespace", nil, nil, "Workflow::DomainConfigurations::Email"] => {name: "CustomEmail"}
+      )
+      response = []
+      listener = build_listener(
+        response: response,
+        node: object_node,
+        call_node: object_node,
+        nesting: ["Workflow", "DomainConfigurations::Email::MtaPending"],
+        index: FakeIndex.new(entries: {"DomainConfigurations::Email" => [email_entry]}),
+        rails_client: rails_client
+      )
+
+      listener.on_call_node_enter(object_node)
+
+      assert_equal ["file:///app/models/domain_configurations/email.rb"], response.map(&:uri)
+      assert_empty rails_client.requests
+    end
+
     it "pushes model method locations for object method calls" do
       object_node = FakeCall.new("object")
       method_node = FakeCall.new("published?", object_node)
@@ -171,7 +213,7 @@ class RubyLsp::HasStateMachine::DefinitionTest < ActiveSupport::TestCase
       assert_equal ["file:///app/models/custom_post.rb"], response.map(&:uri)
     end
 
-    it "prefers the model configured workflow namespace over the convention" do
+    it "prefers convention resolution before Rails workflow namespace lookup" do
       object_node = FakeCall.new("object")
       custom_entry = FakeEntry.new("file:///app/models/custom_post.rb", FakeLocation.new(1, 1, 6, 16))
       rails_client = FakeRailsClient.new(
@@ -188,7 +230,8 @@ class RubyLsp::HasStateMachine::DefinitionTest < ActiveSupport::TestCase
 
       listener.on_call_node_enter(object_node)
 
-      assert_equal ["file:///app/models/custom_post.rb"], response.map(&:uri)
+      assert_equal ["file:///app/models/post.rb"], response.map(&:uri)
+      assert_empty rails_client.requests
     end
   end
 

--- a/test/ruby_lsp/has_state_machine/rails_server_addon_test.rb
+++ b/test/ruby_lsp/has_state_machine/rails_server_addon_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ruby_lsp/has_state_machine/rails_server_addon"
+
+class RubyLsp::HasStateMachine::RailsServerAddonTest < ActiveSupport::TestCase
+  def teardown
+    Object.send(:remove_const, :RubyLspRailsServerAddonCustomPost) if Object.const_defined?(:RubyLspRailsServerAddonCustomPost)
+    Object.send(:remove_const, :RubyLspRailsServerAddonEagerPost) if Object.const_defined?(:RubyLspRailsServerAddonEagerPost)
+    Object.send(:remove_const, :RubyLspRailsServerAddonNotAModel) if Object.const_defined?(:RubyLspRailsServerAddonNotAModel)
+    super
+  end
+
+  describe "#model_for_workflow_namespace" do
+    it "constantizes conventional workflow namespaces without eager loading Rails" do
+      result = without_eager_load do
+        addon.send(:model_for_workflow_namespace, "Workflow::Post")
+      end
+
+      assert_equal({name: "Post"}, result)
+    end
+
+    it "ignores conventional constants that are not Active Record models" do
+      Object.const_set(
+        :RubyLspRailsServerAddonNotAModel,
+        Module.new do
+          define_singleton_method(:workflow_namespace) do
+            "Workflow::RubyLspRailsServerAddonNotAModel"
+          end
+        end
+      )
+
+      result = addon.send(:conventional_model_for_workflow_namespace, "Workflow::RubyLspRailsServerAddonNotAModel")
+
+      assert_nil result
+    end
+
+    it "finds loaded models with non-conventional workflow namespaces without eager loading Rails" do
+      Object.const_set(
+        :RubyLspRailsServerAddonCustomPost,
+        Class.new(ApplicationRecord) do
+          define_singleton_method(:workflow_namespace) do
+            "Publishing::Post"
+          end
+        end
+      )
+
+      result = without_eager_load do
+        addon.send(:model_for_workflow_namespace, "Publishing::Post")
+      end
+
+      assert_equal({name: "RubyLspRailsServerAddonCustomPost"}, result)
+    end
+
+    it "eager loads only as a fallback for unloaded non-conventional workflow namespaces" do
+      result = with_eager_load_defining_model do
+        addon.send(:model_for_workflow_namespace, "Publishing::EagerPost")
+      end
+
+      assert_equal({name: "RubyLspRailsServerAddonEagerPost"}, result)
+    end
+  end
+
+  private
+
+  def addon
+    @addon ||= RubyLsp::HasStateMachine::RailsServerAddon.allocate
+  end
+
+  def without_eager_load(&block)
+    with_eager_load(-> { flunk "expected lookup to avoid eager loading Rails" }, &block)
+  end
+
+  def with_eager_load_defining_model(&block)
+    with_eager_load(-> { define_eager_post }, &block)
+  end
+
+  def with_eager_load(replacement)
+    application = Rails.application
+    singleton_class = class << application; self; end
+    original = application.method(:eager_load!)
+
+    singleton_class.define_method(:eager_load!) { replacement.call }
+    yield
+  ensure
+    singleton_class.define_method(:eager_load!) { |*args, &block| original.call(*args, &block) }
+  end
+
+  def define_eager_post
+    return if Object.const_defined?(:RubyLspRailsServerAddonEagerPost)
+
+    Object.const_set(
+      :RubyLspRailsServerAddonEagerPost,
+      Class.new(ApplicationRecord) do
+        define_singleton_method(:workflow_namespace) do
+          "Publishing::EagerPost"
+        end
+      end
+    )
+  end
+end


### PR DESCRIPTION
# Description
After testing against the main beehiiv application, which ~15,000 Ruby files, I noticed that the Ruby LSP extension added in `v1.2.0` was timing out due to eager loading of all Rails models and their associations. 

This fixes that, better filtering for inheritance of `ActiveRecord::Base`, as well as only loading models that respond to `workflow_namespace` as a method. This update also looks for the default convention (`Workflow`) before fishing for a dynamic `workflow_namespace` on the model. 

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [x] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow models are now resolved using naming conventions first, improving matching for both regular and namespaced workflows.
  * Added broader model lookup support for workflows when a direct convention match isn’t available.

* **Bug Fixes**
  * Improved model resolution priority so convention-based matches are preferred over Rails-based lookups.
  * Reduced unnecessary Rails queries during workflow model detection, which should make resolution more reliable and efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->