### PR TITLE
perf: improve ruby lsp extension caching

### DIFF
--- a/lib/ruby_lsp/has_state_machine/definition.rb
+++ b/lib/ruby_lsp/has_state_machine/definition.rb
@@ -7,22 +7,29 @@ module RubyLsp
     class Definition
       SERVER_ADDON_NAME = "has_state_machine"
 
-      def initialize(response_builder, _uri, node_context, dispatcher, index: nil, rails_client: nil)
+      def initialize(response_builder, _uri, node_context, dispatcher, index: nil, rails_client: nil,
+        model_name_cache: nil)
         @response_builder = response_builder
         @node_context = node_context
         @index = index
         @rails_client = rails_client
+        @model_name_cache = model_name_cache
 
         dispatcher.register(self, :on_call_node_enter)
       end
 
       def on_call_node_enter(node)
         return unless current_target?(node)
-        return unless resolved_model_name
 
+        # Check the node shape first: resolving the model name may require a
+        # round-trip to the Rails runner, so only pay it for `object` calls.
         if object_call?(node)
+          return unless resolved_model_name
+
           push_entries(constant_entries(resolved_model_name))
         elsif object_method_call?(node)
+          return unless resolved_model_name
+
           method_name = message(node)
           entries = method_entries(resolved_model_name, method_name)
           entries = association_entries(resolved_model_name, method_name) if entries.empty?
@@ -33,7 +40,7 @@ module RubyLsp
 
       private
 
-      attr_reader :index, :node_context, :rails_client, :response_builder
+      attr_reader :index, :model_name_cache, :node_context, :rails_client, :response_builder
 
       def current_target?(node)
         target = node_context.node if node_context.respond_to?(:node)
@@ -79,6 +86,18 @@ module RubyLsp
       def model_name_from_rails(workflow_namespace)
         return unless workflow_namespace && rails_client
 
+        # Cache hits and misses for the life of the LSP process; the set of
+        # models rarely changes mid-session. Failures raise past the cache
+        # write, so a slow-to-boot Rails runner can succeed on a later request.
+        cache = model_name_cache.to_h
+        cache.fetch(workflow_namespace) do
+          cache[workflow_namespace] = request_model_name(workflow_namespace)
+        end
+      rescue
+        nil
+      end
+
+      def request_model_name(workflow_namespace)
         result = rails_client.delegate_request(
           server_addon_name: SERVER_ADDON_NAME,
           request_name: "model_for_workflow_namespace",
@@ -86,8 +105,6 @@ module RubyLsp
         )
 
         response_name(result)
-      rescue
-        nil
       end
 
       def association_entries(model_name, association_name)

--- a/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
+++ b/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
@@ -23,10 +23,22 @@ module RubyLsp
       private
 
       def model_for_workflow_namespace(workflow_namespace)
-        model = models_by_workflow_namespace[workflow_namespace]
+        model = conventional_model_for(workflow_namespace) || models_by_workflow_namespace[workflow_namespace]
         return unless model
 
         {name: model.name}
+      end
+
+      ##
+      # Fast path: for the default "Workflow::<Model>" namespace, autoload just
+      # that one constant instead of eager loading the whole application. Only
+      # custom workflow_namespace configurations need the full scan below.
+      def conventional_model_for(workflow_namespace)
+        workflow_namespace = workflow_namespace.to_s
+        return unless workflow_namespace.start_with?("Workflow::")
+
+        model = workflow_namespace.delete_prefix("Workflow::").safe_constantize
+        model if model.try(:workflow_namespace) == workflow_namespace
       end
 
       def models_by_workflow_namespace

--- a/spec/ruby_lsp/has_state_machine/definition_spec.rb
+++ b/spec/ruby_lsp/has_state_machine/definition_spec.rb
@@ -177,6 +177,46 @@ RSpec.describe RubyLsp::HasStateMachine::Definition do
       expect(response.map(&:uri)).to eq(["file:///app/models/custom_post.rb"])
     end
 
+    it "does not contact Rails for unrelated call nodes" do
+      unrelated_node = fakes::FakeCall.new("some_helper")
+      rails_client = fakes::FakeRailsClient.new
+      listener = build_listener(
+        response: [],
+        node: unrelated_node,
+        call_node: unrelated_node,
+        index: fakes::FakeIndex.new,
+        rails_client: rails_client
+      )
+
+      listener.on_call_node_enter(unrelated_node)
+
+      expect(rails_client.requests).to be_empty
+    end
+
+    it "shares the model name cache across listeners" do
+      object_node = fakes::FakeCall.new("object")
+      rails_client = fakes::FakeRailsClient.new(
+        ["model_for_workflow_namespace", nil, nil, "Workflow::Post"] => {name: "Post"}
+      )
+      cache = {}
+      index = fakes::FakeIndex.new(entries: {"Post" => [entry]})
+
+      2.times do
+        listener = build_listener(
+          response: [],
+          node: object_node,
+          call_node: object_node,
+          index: index,
+          rails_client: rails_client,
+          model_name_cache: cache
+        )
+        listener.on_call_node_enter(object_node)
+      end
+
+      expect(rails_client.requests.length).to eq(1)
+      expect(cache).to eq("Workflow::Post" => "Post")
+    end
+
     it "prefers the model configured workflow namespace over the convention" do
       object_node = fakes::FakeCall.new("object")
       custom_entry = fakes::FakeEntry.new("file:///app/models/custom_post.rb", fakes::FakeLocation.new(1, 1, 6, 16))
@@ -198,7 +238,8 @@ RSpec.describe RubyLsp::HasStateMachine::Definition do
     end
   end
 
-  def build_listener(response:, node:, call_node:, index:, rails_client: nil, nesting: ["Workflow", "Post::Draft"])
+  def build_listener(response:, node:, call_node:, index:, rails_client: nil, model_name_cache: nil,
+    nesting: ["Workflow", "Post::Draft"])
     dispatcher = RubyLspHasStateMachineDefinitionSpec::FakeDispatcher.new
     node_context = RubyLspHasStateMachineDefinitionSpec::FakeNodeContext.new(node, call_node, nesting)
 
@@ -208,7 +249,8 @@ RSpec.describe RubyLsp::HasStateMachine::Definition do
       node_context,
       dispatcher,
       index: index,
-      rails_client: rails_client
+      rails_client: rails_client,
+      model_name_cache: model_name_cache
     )
   end
 end


### PR DESCRIPTION
# Description

Two performance improvements to the LSP definition listener:

1. **Skip Rails round-trips for unrelated nodes.** Previously, `resolved_model_name` (which may delegate to the Rails runner) was called before checking whether the node was an `object` call or an `object_method` call. The guard is now moved inside each branch so that unrelated call nodes never trigger a Rails request.
2. **Cache model name lookups across listener instances.** A `model_name_cache` hash can now be passed into the `Definition` listener and shared across multiple instances for the lifetime of the LSP process. Repeated lookups for the same workflow namespace hit the cache instead of spawning a new Rails runner request. Cache failures (e.g. a slow-to-boot Rails process) are not stored, so a later request can still succeed.

Additionally, a fast path was added to `RailsServerAddon` for the conventional `Workflow::<Model>` namespace. Instead of eager-loading the entire application to scan all ActiveRecord models, it autoloads just the one constant and verifies its `workflow_namespace`. Only models with a custom `workflow_namespace` configuration fall through to the full scan.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1\. Major (breaking change)
- [ ] 2\. Minor (non-breaking, backwards compatible change)
- [x] 3\. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4\. No immediate release is required