### PR TITLE
chore: adds release workflow for github tag-based releases

### DIFF
--- a/.github/scripts/write-version.sh
+++ b/.github/scripts/write-version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?usage: write-version.sh <version>}"
+
+cat > lib/has_state_machine/version.rb <<EOF
+# frozen_string_literal: true
+
+module HasStateMachine
+  VERSION = "${VERSION}"
+end
+EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up tools
         uses: jdx/mise-action@v4
@@ -55,13 +56,7 @@ jobs:
             exit 1
           fi
 
-          cat > lib/has_state_machine/version.rb <<EOF
-          # frozen_string_literal: true
-
-          module HasStateMachine
-            VERSION = "${VERSION}"
-          end
-          EOF
+          .github/scripts/write-version.sh "${VERSION}"
 
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Publishing has_state_machine ${VERSION} from ${RELEASE_TAG}"
@@ -80,6 +75,7 @@ jobs:
       - name: Sync version bump to main
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -88,14 +84,7 @@ jobs:
           git fetch origin main
           git checkout -B main origin/main
 
-          cat > lib/has_state_machine/version.rb <<EOF
-          # frozen_string_literal: true
-
-          module HasStateMachine
-            VERSION = "${VERSION}"
-          end
-          EOF
-
+          .github/scripts/write-version.sh "${VERSION}"
           bundle exec rake changelog:refresh
 
           git add lib/has_state_machine/version.rb CHANGELOG.md
@@ -105,4 +94,16 @@ jobs:
           fi
 
           git commit -m "Bump version to ${VERSION}"
-          git push origin main
+
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          for attempt in 1 2 3; do
+            if git push origin main; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); refetching and rebasing"
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "Failed to push version bump to main after retries" >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-gem-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    environment:
+      name: release
+      url: https://rubygems.org/gems/has_state_machine
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Set up tools
+        uses: jdx/mise-action@v4
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Set gem version from release tag
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          case "${RELEASE_TAG}" in
+            v[0-9]*) ;;
+            *)
+              echo "Release tag '${RELEASE_TAG}' must look like v1.2.3" >&2
+              exit 1
+              ;;
+          esac
+
+          VERSION="${RELEASE_TAG#v}"
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag '${RELEASE_TAG}' is not a valid gem version" >&2
+            exit 1
+          fi
+
+          cat > lib/has_state_machine/version.rb <<EOF
+          # frozen_string_literal: true
+
+          module HasStateMachine
+            VERSION = "${VERSION}"
+          end
+          EOF
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Publishing has_state_machine ${VERSION} from ${RELEASE_TAG}"
+
+      - name: Configure RubyGems credentials
+        uses: rubygems/configure-rubygems-credentials@v2
+
+      - name: Build and push gem
+        run: |
+          set -euo pipefail
+          gem build has_state_machine.gemspec
+          mkdir -p pkg
+          mv has_state_machine-*.gem pkg/
+          gem push pkg/*.gem
+
+      - name: Sync version bump to main
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main
+          git checkout -B main origin/main
+
+          cat > lib/has_state_machine/version.rb <<EOF
+          # frozen_string_literal: true
+
+          module HasStateMachine
+            VERSION = "${VERSION}"
+          end
+          EOF
+
+          bundle exec rake changelog:refresh
+
+          git add lib/has_state_machine/version.rb CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "main already at ${VERSION}"
+            exit 0
+          fi
+
+          git commit -m "Bump version to ${VERSION}"
+          git push origin main

--- a/bin/publish
+++ b/bin/publish
@@ -48,7 +48,7 @@ class ReleaseTypeCheck
 
   def initialize
     @release_type = RELEASE_TYPE
-    @allowed_release_types = %w(major minor patch)
+    @allowed_release_types = %w[major minor patch]
   end
 
   def check
@@ -62,23 +62,9 @@ class ReleaseTypeCheck
   end
 end
 
-class RubyGemsCheck
-  def check
-    return true if valid?
-
-    abort("\nError: You must be logged in to RubyGems. Run 'gem signin'")
-  end
-
-  def valid?
-    `gem signin`.empty?
-  end
-end
-
-[ReleaseTypeCheck, BranchCheck, GitCheck, RubyGemsCheck].each do |check_class|
+[ReleaseTypeCheck, BranchCheck, GitCheck].each do |check_class|
   check_class.new.check
 end
-
-APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 current_version = HasStateMachine::VERSION.split(".").map(&:to_i)
 
@@ -95,40 +81,23 @@ when "patch"
 end
 
 new_version = current_version.join(".")
+tag = "v#{new_version}"
 
-puts "--- Bundle Install  ---"
-`bundle install`
-
-puts "--- Updating version to #{new_version} ---"
-
-version_file_contents = <<~FILE
-  # frozen_string_literal: true
-
-  module HasStateMachine
-    VERSION = "#{new_version}"
-  end
-FILE
-
-File.write("#{APP_ROOT}/lib/has_state_machine/version.rb", version_file_contents)
-
-puts "--- Update CHANGELOG ---"
-`bundle exec rake changelog:refresh`
-
-printf "\nAre you ready to commit and release this gem? [Y/n]: "
-prompt = STDIN.gets.chomp
+printf "\nCreate GitHub Release #{tag} (#{RELEASE_TYPE}) and publish to RubyGems? [Y/n]: "
+prompt = $stdin.gets.chomp
 
 if prompt == "Y"
-  puts "--- Adding Files ---"
-  `git add .`
+  puts "--- Creating GitHub Release #{tag} ---"
+  if system("gh", "release", "create", tag, "--generate-notes", "--title", tag, "--target", "main")
+    puts "Release #{tag} created. The Release workflow will set the gem version, publish to RubyGems.org, and sync main."
+  else
+    abort(<<~MSG)
 
-  puts "--- Commiting Changes ---"
-  `git commit -m 'Bump version to #{new_version}'`
+      Failed to create the GitHub Release. Create it manually to publish:
 
-  puts "--- Pushing Changes ---"
-  `git push origin main`
-
-  puts "--- Action Required: Publish Gem ---"
-  puts "Now run `bundle exec rake release` to publish the gem to rubygems"
+        gh release create #{tag} --generate-notes --target main
+    MSG
+  end
 else
   puts "--- Aborting Gem Release ---"
 end

--- a/bin/publish
+++ b/bin/publish
@@ -84,9 +84,9 @@ new_version = current_version.join(".")
 tag = "v#{new_version}"
 
 printf "\nCreate GitHub Release #{tag} (#{RELEASE_TYPE}) and publish to RubyGems? [Y/n]: "
-prompt = $stdin.gets.chomp
+prompt = $stdin.gets.to_s.strip
 
-if prompt == "Y"
+if prompt.empty? || prompt.match?(/\A(y|yes)\z/i)
   puts "--- Creating GitHub Release #{tag} ---"
   if system("gh", "release", "create", tag, "--generate-notes", "--title", tag, "--target", "main")
     puts "Release #{tag} created. The Release workflow will set the gem version, publish to RubyGems.org, and sync main."
@@ -95,7 +95,7 @@ if prompt == "Y"
 
       Failed to create the GitHub Release. Create it manually to publish:
 
-        gh release create #{tag} --generate-notes --target main
+        gh release create #{tag} --generate-notes --title #{tag} --target main
     MSG
   end
 else


### PR DESCRIPTION
# Description

Automates the gem release process by introducing a GitHub Actions `release.yml` workflow that triggers on published GitHub Releases. When a release is created, the workflow validates the tag format, sets the gem version from the tag, builds and pushes the gem to RubyGems.org using OIDC-based trusted publishing, and then syncs the version bump and refreshed changelog back to `main`.

The `bin/publish` script has been updated to reflect this new flow. Instead of manually writing the version file, committing, pushing, and prompting the user to run `rake release`, it now simply creates a GitHub Release via the `gh` CLI using `--generate-notes`. The `RubyGemsCheck` class has been removed since RubyGems authentication is now handled by the CI workflow.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1\. Major (breaking change)
- [ ] 2\. Minor (non-breaking, backwards compatible change)
- [ ] 3\. Patch (non-breaking, backwards compatible bug fix)
- [x] 4\. No immediate release is required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->