### PR TITLE
fix: defer after_transition_commit callbacks until the outermost transaction commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ module Workflow
     end
 
     # after_transition_commit runs only once the transition has been
-    # committed: after the record is saved for normal transitions, and
-    # outside the transaction for transactional transitions (see below).
+    # committed to the database: after the OUTERMOST database transaction
+    # commits, or immediately after the transition when no transaction is
+    # open. It never runs if the transition or a surrounding transaction
+    # rolls back. (Requires Rails 7.2+; see Advanced Usage below.)
     after_transition_commit do
       MyJob.perform_later(object)
     end
@@ -231,6 +233,20 @@ module Workflow
   end
 end
 ```
+
+#### `after_transition_commit` Semantics
+
+`after_transition_commit` callbacks run after the outermost database transaction commits. In detail:
+
+- If no transaction is open when `transition_to` is called, they run immediately after the transition commits.
+- If the transition happens inside an open transaction — an app-level `ActiveRecord::Base.transaction`, or a nested transition triggered from another state's `before_transition`/`after_transition` — they are deferred until that outermost transaction commits.
+- They never run if the transition fails, if `rollback_transition` is raised, or if a surrounding transaction rolls back after the transition. Multiple transitions inside one transaction each fire their callbacks after commit, in transition order.
+
+This makes `after_transition_commit` the safe place to enqueue background jobs, call external APIs, etc.: the work only happens once the new state is actually visible to other database connections.
+
+**Note on Rails versions:** deferral to an outer transaction requires Rails 7.2+. On older Rails versions the callbacks fire as soon as the transition itself completes, which may be inside an uncommitted outer transaction.
+
+**Footgun: `ActiveRecord.after_all_transactions_commit`** does not work as a substitute inside `before_transition`/`after_transition`. Rails skips non-joinable transactions when deciding whether any transaction is open, and transactional transitions run inside the gem's own non-joinable transaction — so the block yields *immediately*, while the transition is still uncommitted. Use `after_transition_commit` instead.
 
 #### Transient Transition Variables
 

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -16,8 +16,8 @@ module HasStateMachine
     define_model_callbacks :transition, only: %i[before after]
 
     ##
-    # Defines the after_transition_commit callback. It runs only after a
-    # transition has committed.
+    # Defines the after_transition_commit callback, which runs once a
+    # successful transition is committed to the database.
     define_model_callbacks :transition_commit, only: %i[after]
 
     ##
@@ -63,7 +63,7 @@ module HasStateMachine
     # @return [Boolean] whether or not the transition took place
     def transition_to(desired_state, **options)
       transitioned = false
-      options = options.transform_keys(&:to_sym)
+      options = options.symbolize_keys
       desired_state_instance = state_instance(desired_state, options)
 
       with_transition_options(options) do
@@ -78,44 +78,65 @@ module HasStateMachine
 
       transitioned
     ensure
-      (desired_state_instance&.errors || []).each do |error|
+      desired_state_instance&.errors&.each do |error|
         object.errors.add(error.attribute, error.type)
       end
     end
 
     ##
     # Makes the actual transition from one state to the next and
-    # runs the before and after transition callbacks. The
-    # after_transition_commit callbacks run after the update completes
-    # and only when it succeeds.
-    def perform_transition!
-      run_callbacks :transition_commit do
-        run_callbacks :transition do
-          object.update("#{object.state_attribute}": state)
-        end
+    # runs the before and after transition callbacks.
+    #
+    # @return [Boolean] whether or not the transition succeeded
+    def perform_transition! # rubocop:disable Naming/PredicateMethod -- public API
+      transitioned = run_callbacks :transition do
+        object.update("#{object.state_attribute}": state)
       end
+      return false unless transitioned
+
+      @previous_state = previous_state
+      enqueue_transition_commit_callbacks
+      true
     end
 
     ##
-    # Makes the actual transition from one state to the next and
-    # runs the before and after transition callbacks in a transaction
-    # to allow for roll backs. The after_transition_commit callbacks run
-    # outside the transaction and only when it commits (not on rollback).
-    def perform_transactional_transition!
-      run_callbacks :transition_commit do
-        ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
-          run_callbacks :transition do
-            rollback_transition unless object.update("#{object.state_attribute}": state)
-          end
+    # Same as {#perform_transition!}, but wrapped in a transaction so
+    # callbacks can roll the transition back.
+    #
+    # @return [Boolean] whether or not the transition succeeded
+    def perform_transactional_transition! # rubocop:disable Naming/PredicateMethod -- public API
+      ActiveRecord::Base.transaction(requires_new: true, joinable: false) do
+        run_callbacks :transition do
+          rollback_transition unless object.update("#{object.state_attribute}": state)
         end
-
-        @previous_state = previous_state
-
-        object.reload.public_send(object.state_attribute) == state
       end
+
+      @previous_state = previous_state
+      return false unless object.reload.public_send(object.state_attribute) == state
+
+      enqueue_transition_commit_callbacks
+      true
     end
 
     private
+
+    ##
+    # Runs the after_transition_commit callbacks once the outermost open
+    # transaction commits, discarding them on rollback.
+    #
+    # @note Registers on the connection's current transaction because
+    #   +ActiveRecord.after_all_transactions_commit+ ignores non-joinable
+    #   transactions (like the gem's own) and would fire immediately.
+    # @return [void]
+    def enqueue_transition_commit_callbacks
+      current_transaction = object.class.connection.current_transaction
+
+      # Rails < 7.2 has no Transaction#after_commit, so callbacks fire
+      # immediately with no deferral. Drop this guard at Rails 7.2+.
+      return run_callbacks(:transition_commit) { true } unless current_transaction.respond_to?(:after_commit)
+
+      current_transaction.after_commit { run_callbacks(:transition_commit) { true } }
+    end
 
     def rollback_transition
       raise ActiveRecord::Rollback

--- a/spec/has_state_machine/state_spec.rb
+++ b/spec/has_state_machine/state_spec.rb
@@ -10,19 +10,21 @@ class Swimmer < ActiveRecord::Base
   attr_accessor :after_transition_commit_boolean
   attr_accessor :previous_state
   attr_accessor :previous_state_in_commit
+  attr_accessor :buddy
+  attr_accessor :buddy_commit_ran_during_transition
   attr_writer :callback_sequence
 
   def callback_sequence
     @callback_sequence ||= []
   end
 
-  has_state_machine states: %i[diving swimming floating tanning tubing lotioning]
+  has_state_machine states: %i[diving swimming floating tanning tubing lotioning racing]
 end
 
 module Workflow
   module Swimmer
     class Diving < HasStateMachine::State
-      state_options transitions_to: %i[swimming floating tanning tubing lotioning]
+      state_options transitions_to: %i[swimming floating tanning tubing lotioning racing]
     end
 
     class Swimming < HasStateMachine::State
@@ -83,15 +85,36 @@ module Workflow
         object.previous_state_in_commit = previous_state
       end
     end
+
+    class Racing < HasStateMachine::State
+      state_options transactional: true, transients: %i[rollback_after]
+
+      after_transition do
+        object.buddy.status.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: true)
+        object.buddy_commit_ran_during_transition = object.buddy.after_transition_commit_boolean
+        rollback_transition if rollback_after
+      end
+    end
   end
 end
 
 RSpec.describe HasStateMachine::State do
+  # Commit-deferral semantics need real COMMITs, which the transactional
+  # fixture wrapper never issues.
+  self.use_transactional_tests = false
+
+  after { Swimmer.delete_all }
+
   let(:object) { Swimmer.create }
   subject { Workflow::Swimmer::Diving.new(object) }
 
+  # Rails < 7.2 lacks Transaction#after_commit, so callbacks fire immediately.
+  def self.supports_deferred_commit_callbacks?
+    ActiveRecord.version >= Gem::Version.new("7.2")
+  end
+
   describe "#possible_transitions" do
-    it { expect(subject.possible_transitions).to eq(%w[swimming floating tanning tubing lotioning]) }
+    it { expect(subject.possible_transitions).to eq(%w[swimming floating tanning tubing lotioning racing]) }
   end
 
   describe "#can_transition?" do
@@ -232,6 +255,83 @@ RSpec.describe HasStateMachine::State do
         it "has access to the previous state in after_transition_commit" do
           subject.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: true)
           expect(object.previous_state_in_commit).to eq("diving")
+        end
+      end
+    end
+
+    if supports_deferred_commit_callbacks?
+      describe "inside an app-level transaction" do
+        it "defers after_transition_commit until the outer transaction commits" do
+          ActiveRecord::Base.transaction do
+            subject.transition_to(:swimming)
+            expect(object.after_transition_commit_boolean).to be_falsey
+          end
+
+          expect(object.after_transition_commit_boolean).to be(true)
+          expect(object.previous_state_in_commit).to eq("diving")
+        end
+
+        it "does not run after_transition_commit when the outer transaction rolls back" do
+          ActiveRecord::Base.transaction do
+            subject.transition_to(:swimming)
+            raise ActiveRecord::Rollback
+          end
+
+          expect(object.after_transition_commit_boolean).to be_falsey
+        end
+
+        it "defers transactional after_transition_commit until the outer transaction commits" do
+          ActiveRecord::Base.transaction do
+            subject.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: true)
+            expect(object.after_transition_commit_boolean).to be_falsey
+          end
+
+          expect(object.after_transition_commit_boolean).to be(true)
+        end
+
+        it "does not run transactional after_transition_commit when the outer transaction rolls back" do
+          ActiveRecord::Base.transaction do
+            subject.transition_to(:lotioning, needs_lotion_before: true, needs_lotion_after: true)
+            raise ActiveRecord::Rollback
+          end
+
+          expect(object.after_transition_commit_boolean).to be_falsey
+        end
+
+        it "fires callbacks for sequential transitions in transition order" do
+          buddy = Swimmer.create
+          sequence = []
+          allow(object).to receive(:after_transition_commit_boolean=) { sequence << :first }
+          allow(buddy).to receive(:after_transition_commit_boolean=) { sequence << :second }
+
+          ActiveRecord::Base.transaction do
+            subject.transition_to(:swimming)
+            Workflow::Swimmer::Diving.new(buddy).transition_to(:swimming)
+            expect(sequence).to be_empty
+          end
+
+          expect(sequence).to eq(%i[first second])
+        end
+      end
+
+      describe "nested transitions" do
+        let(:buddy) { Swimmer.create }
+
+        before { object.buddy = buddy }
+
+        it "defers the inner record's after_transition_commit until the outermost commit" do
+          expect(subject.transition_to(:racing)).to be(true)
+
+          expect(object.buddy_commit_ran_during_transition).to be_falsey
+          expect(buddy.after_transition_commit_boolean).to be(true)
+          expect(buddy.reload.status).to eq("lotioning")
+        end
+
+        it "does not run the inner record's after_transition_commit when the outer transition rolls back" do
+          expect(subject.transition_to(:racing, rollback_after: true)).to be(false)
+
+          expect(buddy.after_transition_commit_boolean).to be_falsey
+          expect(buddy.reload.status).to eq("diving")
         end
       end
     end


### PR DESCRIPTION
# Description

Reworks `after_transition_commit` so that callbacks are deferred until the **outermost** database transaction commits, rather than firing as soon as the transition's own write completes. This means callbacks are skipped entirely if the transition or any surrounding transaction rolls back — making it safe to enqueue background jobs, call external APIs, or perform any work that should only happen once the new state is durably visible to other database connections.

The core change replaces the previous `run_callbacks :transition_commit` wrapping approach with `enqueue_transition_commit_callbacks`, which registers callbacks directly on the connection's current transaction via `Transaction#after_commit`. This correctly handles:

- Transitions called outside any transaction (callbacks fire immediately after the transition commits)
- Transitions inside an app-level `ActiveRecord::Base.transaction` (callbacks are deferred until that outer transaction commits)
- Nested transitions triggered from `before_transition`/`after_transition` of another state (the inner record's callbacks are also deferred to the outermost commit)
- Multiple transitions within a single transaction (each fires its callbacks after commit, in transition order)

A Rails version guard is included: `Transaction#after_commit` was introduced in Rails 7.2, so on older versions callbacks fire immediately as before.

The README documents the new semantics, including a note warning against using `ActiveRecord.after_all_transactions_commit` as a substitute inside transition callbacks, since Rails skips non-joinable transactions (like the gem's own) when evaluating whether any transaction is open.

Tests are updated to use non-transactional fixtures so real `COMMIT` statements are issued, and new specs cover all of the deferral and rollback scenarios described above.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1\. Major (breaking change)
- [x] 2\. Minor (non-breaking, backwards compatible change)
- [ ] 3\. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4\. No immediate release is required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->