### PR TITLE
fix(lsp): repair go-to-definition in workflow states and release push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       url: https://rubygems.org/gems/has_state_machine
 
     permissions:
-      contents: write
+      contents: read
       id-token: write
 
     steps:
@@ -72,10 +72,17 @@ jobs:
           mv has_state_machine-*.gem pkg/
           gem push pkg/*.gem
 
+      - name: Mint deploy-bot token
+        uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEPLOY_BOT_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_BOT_APP_PRIVATE_KEY }}
+
       - name: Sync version bump to main
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -103,7 +110,9 @@ jobs:
             fi
             echo "Push rejected (attempt ${attempt}); refetching and rebasing"
             git fetch origin main
-            git rebase origin/main
+            # Autostash: changelog:refresh leaves Gemfile.lock dirty (bundler
+            # relocks the bumped gemspec version), which otherwise aborts rebase.
+            git rebase --autostash origin/main
           done
           echo "Failed to push version bump to main after retries" >&2
           exit 1

--- a/lib/ruby_lsp/has_state_machine/addon.rb
+++ b/lib/ruby_lsp/has_state_machine/addon.rb
@@ -15,9 +15,16 @@ module RubyLsp
         @model_name_cache = {}
         @rails_client = register_rails_server_addon(outgoing_queue)
 
-        rails_status = @rails_client ? "registered" : "unavailable, using naming convention only"
-        log(outgoing_queue,
-          "Activating Has State Machine Ruby LSP add-on v#{version} (Rails integration: #{rails_status})")
+        rails_status = if @rails_client
+          "registered"
+        else
+          "unavailable, using naming convention only"
+        end
+
+        log(
+          outgoing_queue,
+          "Activating Has State Machine Ruby LSP add-on v#{version} (Rails integration: #{rails_status})"
+        )
       end
 
       def deactivate

--- a/lib/ruby_lsp/has_state_machine/addon.rb
+++ b/lib/ruby_lsp/has_state_machine/addon.rb
@@ -12,12 +12,18 @@ module RubyLsp
     class Addon < ::RubyLsp::Addon
       def activate(global_state, outgoing_queue)
         @global_state = global_state
+        @model_name_cache = {}
         @rails_client = register_rails_server_addon(outgoing_queue)
+
+        rails_status = @rails_client ? "registered" : "unavailable, using naming convention only"
+        log(outgoing_queue,
+          "Activating Has State Machine Ruby LSP add-on v#{version} (Rails integration: #{rails_status})")
       end
 
       def deactivate
         @global_state = nil
         @rails_client = nil
+        @model_name_cache = nil
       end
 
       def name
@@ -35,7 +41,8 @@ module RubyLsp
           node_context,
           dispatcher,
           index: @global_state&.index,
-          rails_client: @rails_client
+          rails_client: @rails_client,
+          model_name_cache: @model_name_cache
         )
       end
 
@@ -53,6 +60,7 @@ module RubyLsp
 
         client = rails_addon.rails_runner_client
         return unless client.respond_to?(:register_server_addon)
+        return if client.respond_to?(:connected?) && !client.connected?
 
         client.register_server_addon(File.expand_path("rails_server_addon.rb", __dir__))
         client

--- a/lib/ruby_lsp/has_state_machine/definition.rb
+++ b/lib/ruby_lsp/has_state_machine/definition.rb
@@ -84,7 +84,7 @@ module RubyLsp
       end
 
       def model_name_from_rails(workflow_namespace)
-        return unless workflow_namespace && rails_client
+        return unless workflow_namespace && rails_client_available?
 
         # Cache hits and misses for the life of the LSP process; the set of
         # models rarely changes mid-session. Failures raise past the cache
@@ -114,8 +114,17 @@ module RubyLsp
         constant_entries(association_model_name)
       end
 
+      # Delegating a request to a disconnected client (ruby-lsp-rails NullClient)
+      # never produces a response, so read_response would block forever and the
+      # convention fallback would never run.
+      def rails_client_available?
+        return false unless rails_client
+
+        !rails_client.respond_to?(:connected?) || rails_client.connected?
+      end
+
       def association_model_name(model_name, association_name)
-        return unless rails_client&.respond_to?(:association_target)
+        return unless rails_client_available? && rails_client.respond_to?(:association_target)
 
         result = rails_client.association_target(model_name: model_name, association_name: association_name)
         response_name(result)

--- a/lib/ruby_lsp/has_state_machine/definition.rb
+++ b/lib/ruby_lsp/has_state_machine/definition.rb
@@ -7,6 +7,10 @@ module RubyLsp
     class Definition
       SERVER_ADDON_NAME = "has_state_machine"
 
+      # AR methods that return self, so `object.reload.foo` targets the model
+      # just like `object.foo`.
+      SELF_RETURNING_METHODS = ["reload"].freeze
+
       def initialize(response_builder, _uri, node_context, dispatcher, index: nil, rails_client: nil,
         model_name_cache: nil)
         @response_builder = response_builder
@@ -33,6 +37,7 @@ module RubyLsp
           method_name = message(node)
           entries = method_entries(resolved_model_name, method_name)
           entries = association_entries(resolved_model_name, method_name) if entries.empty?
+          entries = constant_entries(resolved_model_name) if entries.empty?
 
           push_entries(entries)
         end
@@ -198,7 +203,14 @@ module RubyLsp
       end
 
       def object_method_call?(node)
-        message(node) && object_call?(receiver(node))
+        message(node) && object_chain?(receiver(node))
+      end
+
+      def object_chain?(node)
+        return false unless node
+        return true if object_call?(node)
+
+        SELF_RETURNING_METHODS.include?(message(node)) && object_chain?(receiver(node))
       end
 
       def object_call?(node)

--- a/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
+++ b/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "ruby_lsp/ruby_lsp_rails/server"
+require "ruby_lsp/ruby_lsp_rails/server" unless defined?(::RubyLsp::Rails::ServerAddon)
 
 module RubyLsp
   module HasStateMachine

--- a/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
+++ b/lib/ruby_lsp/has_state_machine/rails_server_addon.rb
@@ -13,7 +13,7 @@ module RubyLsp
         with_request_error_handling(request) do
           case request
           when "model_for_workflow_namespace"
-            send_result(model_for_workflow_namespace(params.fetch("workflow_namespace")))
+            send_result(model_for_workflow_namespace(params[:workflow_namespace] || params.fetch("workflow_namespace")))
           else
             raise NotImplementedError, "Unknown request: #{request}"
           end

--- a/spec/ruby_lsp/has_state_machine/addon_spec.rb
+++ b/spec/ruby_lsp/has_state_machine/addon_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "ruby-lsp"
+require "ruby_lsp/internal"
+require "ruby_lsp/has_state_machine/addon"
+
+module RubyLspHasStateMachineAddonSpec
+  class FakeRunnerClient
+    attr_reader :registrations
+
+    def initialize(connected:)
+      @connected = connected
+      @registrations = []
+    end
+
+    def connected?
+      @connected
+    end
+
+    def register_server_addon(path)
+      @registrations << path
+    end
+  end
+
+  FakeRailsAddon = Struct.new(:rails_runner_client)
+end
+
+RSpec.describe RubyLsp::HasStateMachine::Addon do
+  let(:fakes) { RubyLspHasStateMachineAddonSpec }
+  let(:addon) { described_class.new }
+  let(:queue) { Queue.new }
+
+  def drain(queue)
+    messages = []
+    messages << queue.pop until queue.empty?
+    messages
+  end
+
+  def stub_rails_addon(client)
+    allow(::RubyLsp::Addon).to receive(:get).and_return(fakes::FakeRailsAddon.new(client))
+  end
+
+  describe "#activate" do
+    it "registers the server addon on a connected Rails runner client and logs activation" do
+      client = fakes::FakeRunnerClient.new(connected: true)
+      stub_rails_addon(client)
+
+      addon.activate(nil, queue)
+
+      expect(client.registrations).to contain_exactly(a_string_ending_with("rails_server_addon.rb"))
+      log = drain(queue).map { |message| message.params.message }.join("\n")
+      expect(log).to include("Activating Has State Machine Ruby LSP add-on v#{HasStateMachine::VERSION}")
+      expect(log).to include("registered")
+    end
+
+    it "skips registration when the Rails runner client is not connected" do
+      client = fakes::FakeRunnerClient.new(connected: false)
+      stub_rails_addon(client)
+
+      addon.activate(nil, queue)
+
+      expect(client.registrations).to be_empty
+      log = drain(queue).map { |message| message.params.message }.join("\n")
+      expect(log).to include("unavailable")
+    end
+
+    it "activates without the Rails addon installed" do
+      allow(::RubyLsp::Addon).to receive(:get).and_raise(::RubyLsp::Addon::AddonNotFoundError)
+
+      addon.activate(nil, queue)
+
+      log = drain(queue).map { |message| message.params.message }.join("\n")
+      expect(log).to include("Activating Has State Machine Ruby LSP add-on")
+    end
+  end
+end

--- a/spec/ruby_lsp/has_state_machine/definition_spec.rb
+++ b/spec/ruby_lsp/has_state_machine/definition_spec.rb
@@ -184,6 +184,62 @@ RSpec.describe RubyLsp::HasStateMachine::Definition do
       expect(response.map(&:uri)).to eq(["file:///app/models/custom_post.rb"])
     end
 
+    it "falls back to the model class for column attribute methods with no definition" do
+      object_node = fakes::FakeCall.new("object")
+      method_node = fakes::FakeCall.new("completed_at", object_node)
+      response = []
+      listener = build_listener(
+        response: response,
+        node: method_node,
+        call_node: method_node,
+        index: fakes::FakeIndex.new(entries: {"Post" => [entry]})
+      )
+
+      listener.on_call_node_enter(method_node)
+
+      expect(response.map(&:uri)).to eq(["file:///app/models/post.rb"])
+    end
+
+    it "resolves methods chained through reload" do
+      object_node = fakes::FakeCall.new("object")
+      reload_node = fakes::FakeCall.new("reload", object_node)
+      method_node = fakes::FakeCall.new("published?", reload_node)
+      method_entry = fakes::FakeEntry.new("file:///app/models/post.rb", fakes::FakeLocation.new(7, 7, 6, 16))
+      response = []
+      listener = build_listener(
+        response: response,
+        node: method_node,
+        call_node: method_node,
+        index: fakes::FakeIndex.new(
+          entries: {"Post" => [entry]},
+          methods: {["Post", "published?"] => [method_entry]}
+        )
+      )
+
+      listener.on_call_node_enter(method_node)
+
+      expect(response.map(&:uri)).to eq(["file:///app/models/post.rb"])
+      expect(response.first.range.start.line).to eq(6)
+    end
+
+    it "ignores methods chained through non-self-returning calls" do
+      object_node = fakes::FakeCall.new("object")
+      parent_node = fakes::FakeCall.new("parent", object_node)
+      method_node = fakes::FakeCall.new("published?", parent_node)
+      rails_client = fakes::FakeRailsClient.new
+      listener = build_listener(
+        response: [],
+        node: method_node,
+        call_node: method_node,
+        index: fakes::FakeIndex.new(entries: {"Post" => [entry]}),
+        rails_client: rails_client
+      )
+
+      listener.on_call_node_enter(method_node)
+
+      expect(rails_client.requests).to be_empty
+    end
+
     it "falls back to the naming convention when the Rails client is disconnected" do
       object_node = fakes::FakeCall.new("object")
       rails_client = fakes::FakeRailsClient.new

--- a/spec/ruby_lsp/has_state_machine/definition_spec.rb
+++ b/spec/ruby_lsp/has_state_machine/definition_spec.rb
@@ -71,11 +71,18 @@ module RubyLspHasStateMachineDefinitionSpec
   class FakeRailsClient
     attr_reader :requests, :association_requests
 
+    attr_writer :connected
+
     def initialize(delegate_responses = {}, association_responses = {})
       @delegate_responses = delegate_responses
       @association_responses = association_responses
+      @connected = true
       @requests = []
       @association_requests = []
+    end
+
+    def connected?
+      @connected
     end
 
     def delegate_request(**params)
@@ -175,6 +182,41 @@ RSpec.describe RubyLsp::HasStateMachine::Definition do
       listener.on_call_node_enter(object_node)
 
       expect(response.map(&:uri)).to eq(["file:///app/models/custom_post.rb"])
+    end
+
+    it "falls back to the naming convention when the Rails client is disconnected" do
+      object_node = fakes::FakeCall.new("object")
+      rails_client = fakes::FakeRailsClient.new
+      rails_client.connected = false
+      response = []
+      listener = build_listener(
+        response: response,
+        node: object_node,
+        call_node: object_node,
+        index: fakes::FakeIndex.new(entries: {"Post" => [entry]}),
+        rails_client: rails_client
+      )
+
+      listener.on_call_node_enter(object_node)
+
+      expect(rails_client.requests).to be_empty
+      expect(response.map(&:uri)).to eq(["file:///app/models/post.rb"])
+    end
+
+    it "resolves via convention when there is no Rails client" do
+      object_node = fakes::FakeCall.new("object")
+      response = []
+      listener = build_listener(
+        response: response,
+        node: object_node,
+        call_node: object_node,
+        index: fakes::FakeIndex.new(entries: {"Post" => [entry]}),
+        rails_client: nil
+      )
+
+      listener.on_call_node_enter(object_node)
+
+      expect(response.map(&:uri)).to eq(["file:///app/models/post.rb"])
     end
 
     it "does not contact Rails for unrelated call nodes" do

--- a/spec/ruby_lsp/has_state_machine/rails_server_addon_spec.rb
+++ b/spec/ruby_lsp/has_state_machine/rails_server_addon_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "ruby_lsp/has_state_machine/rails_server_addon"
+
+RSpec.describe RubyLsp::HasStateMachine::RailsServerAddon do
+  let(:stdout) { StringIO.new }
+  let(:addon) { described_class.new(stdout, StringIO.new, {}) }
+
+  def last_result
+    json = stdout.string.split("\r\n\r\n").last
+    JSON.parse(json, symbolize_names: true)
+  end
+
+  describe "#execute" do
+    it "resolves the model from symbol-keyed params (as sent by ruby-lsp-rails)" do
+      addon.execute("model_for_workflow_namespace", {workflow_namespace: "Workflow::Post"})
+
+      expect(last_result).to eq(result: {name: "Post"})
+    end
+
+    it "also accepts string-keyed params" do
+      addon.execute("model_for_workflow_namespace", {"workflow_namespace" => "Workflow::Post"})
+
+      expect(last_result).to eq(result: {name: "Post"})
+    end
+
+    it "returns a nil result for unknown namespaces" do
+      addon.execute("model_for_workflow_namespace", {workflow_namespace: "Workflow::Missing"})
+
+      expect(last_result).to eq(result: nil)
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR fixes the Ruby LSP add-on so that go-to-definition on object inside workflow state classes actually jumps to the ActiveRecord model. 

The Rails server addon now reads the symbolized params that `ruby-lsp-rails` sends (the old string-key fetch raised a KeyError on every request), the addon skips server-addon registration when the Rails runner client is still a disconnected `NullClient` so definition requests can't hang on a client that will never respond, and the definition listener falls back to the `Workflow::Model::State` naming convention whenever the Rails client is missing or disconnected. 

Activation is now logged to the Ruby LSP output (including whether Rails integration registered), and the previously unused model-name cache is wired up so namespace lookups are cached for the life of the LSP process. The release workflow is also updated to push the post-release version bump to main using a `beehiiv-deploy-bot` app token instead of the default `GITHUB_TOKEN` (which branch protection rejects), and its retry rebase now autostashes to survive the dirty Gemfile.lock left by the changelog refresh.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [x] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
